### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,8 +20,6 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
-
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+  
+
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
       <li class='list'>
-         <%= link_to "#" do %>
+         <%= link_to item_path(item.id) do %>
          
         <div class='item-img-content'>
           <%= image_tag item.image, class: 'item-img'  %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,21 +23,21 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
+    <% if user_signed_in?%>
+      <% if current_user.id == @item.user_id %> 
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
 
-    <% if user_signed_in? && current_user.id != @item.user_id %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
 
-    <% if user_signed_in? && current_user.id =! @item.user_id %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,27 +4,27 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
@@ -33,7 +33,7 @@
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_to_ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
@@ -34,7 +33,6 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <% end %>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,9 @@
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
+    <% if user_signed_in? && current_user.id =! @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -102,7 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= @item.category %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,8 +16,8 @@
     <% if user_signed_in? %>
     <ul class='lists-right'>
       
-      <li><%= link_to current_user.nickname, "#", class: "user-nickname" </li> %>
-      <li><%= link_to 'ログアウト',destroy_user_session_path, method: :delete, class: "logout" </li> %>
+      <li><%= link_to current_user.nickname, "#", class: "user-nickname"  %></li>
+      <li><%= link_to 'ログアウト',destroy_user_session_path, method: :delete, class: "logout"  %></li>
       <% else %>
       <li><%= link_to 'ログイン', new_user_session_path, class: "login" %></li>
       <li><%= link_to '新規登録', new_user_registration_path, class: "sign-up" %></li>


### PR DESCRIPTION
商品詳細表示機能の実装を行ました。
ご確認をお願いいたします。

#what
商品詳細表示機能の実装

#why
投稿した商品の詳細を表示するため

動作確認

商品の画像から詳細ページに移動ができる。
ログインしたユーザーが商品を投稿したユーザーなら
編集と削除のボタンが確認できる
https://gyazo.com/2d4e19a5762746310c0ac42e1b513eb3

ログインユーザーが商品を投稿したユーザーではないなら
編集と削除のボタンが存在せず、商品の購入ボタンが存在する。
https://gyazo.com/021ff9b0ddec51f073245d26a3aeca33

ログアウト状態のユーザーでも詳細ページを閲覧できる。
詳細ページには、編集・削除・購入のボタンが存在しない
https://gyazo.com/056e9c725e6821e466bbbc21794b524e